### PR TITLE
docs: recommend apt packages for age and tofu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,20 @@ This project is written in Go and uses Go modules for dependency management. The
 ## Setup
 
 1. Install Go 1.24 or later.
-2. Download dependencies with:
+2. Install age:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y age
+```
+
+3. Install OpenTofu:
+
+```sh
+sudo apt-get install -y tofu
+```
+
+4. Download dependencies with:
 
 ```sh
 $ go mod download


### PR DESCRIPTION
## Summary
- document installing age via `apt-get`
- document installing OpenTofu (package `tofu`) via `apt-get`

## Testing
- `go mod download`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb83fbd97883269d532ba59b8795f6