### PR TITLE
Add test for malformed stdin JSON

### DIFF
--- a/testdata/invalid-json-input.txtar
+++ b/testdata/invalid-json-input.txtar
@@ -1,0 +1,11 @@
+stdin stdin.json
+! exec tofu-age-encryption --encrypt
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- stdin.json --
+{
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to parse stdin: unexpected end of JSON input


### PR DESCRIPTION
## Summary
- add test case for invalid JSON input ensuring parser error is surfaced

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb973e4a048326b7862a10e90b7deb