### PR TITLE
test: handle missing age binary

### DIFF
--- a/testdata/age-missing-decrypt.txtar
+++ b/testdata/age-missing-decrypt.txtar
@@ -1,0 +1,12 @@
+stdin input.json
+! exec sh -c 'cmd=$(command -v tofu-age-encryption); PATH=/nonexistent "$cmd" --decrypt'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- input.json --
+{"payload":"aGVsbG8="}
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to decrypt payload: failed to decrypt payload with age: exec: "age": executable file not found in $PATH

--- a/testdata/age-missing-encrypt.txtar
+++ b/testdata/age-missing-encrypt.txtar
@@ -1,0 +1,12 @@
+stdin input.json
+! exec sh -c 'cmd=$(command -v tofu-age-encryption); PATH=/nonexistent "$cmd" --encrypt'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- input.json --
+{"payload":"aGVsbG8="}
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to encrypt payload: failed to encrypt payload with age: exec: "age": executable file not found in $PATH


### PR DESCRIPTION
## Summary
- add regression tests for missing `age` executable when encrypting and decrypting

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb9729a1fc8326a085623864a41791