### PR TITLE
Add tests for missing and mismatched age identities

### DIFF
--- a/testdata/decrypt-missing-identity.txtar
+++ b/testdata/decrypt-missing-identity.txtar
@@ -1,0 +1,14 @@
+env AGE_IDENTITY_FILE=missing
+
+! exec sh -c 'tofu-age-encryption --decrypt <input.json'
+cmp stdout stdout.json
+cmp stderr stderr.txt
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to decrypt payload: age: error: reading "missing": failed to open file: open missing: no such file or directory
+age: report unexpected or unhelpful errors at https://filippo.io/age/report

--- a/testdata/decrypt-wrong-identity.txtar
+++ b/testdata/decrypt-wrong-identity.txtar
@@ -1,0 +1,18 @@
+env AGE_IDENTITY_FILE=key-b.txt
+! exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.json
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key-b.txt --
+# created: 2025-09-06T01:25:41Z
+# public key: age1yh02jaysl73ph50r4xrage2hvstp9hjy72r4p4tlv99zveyf9fvsxc4h9n
+AGE-SECRET-KEY-1UTNEY8FW0GN8CXZT8KERWNL9TGDVMQYRT86C6WZQGKTDWTRL7E4Q6CMNMM
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to decrypt payload: age: error: no identity matched any of the recipients
+age: report unexpected or unhelpful errors at https://filippo.io/age/report


### PR DESCRIPTION
## Summary
- add test covering decryption failure when identity file is missing
- add test covering decryption failure when identity lacks matching keys

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb97380ee88326beb5686aee50d1e8