### PR TITLE
Handle help flag and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,11 +37,13 @@ func main() {
 	ctx := context.Background()
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	var usage bytes.Buffer
-	fs.SetOutput(&usage)
+	fs.SetOutput(io.Discard)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stdout, "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
+		origOutput := fs.Output()
+		fs.SetOutput(os.Stdout)
 		fs.PrintDefaults()
+		fs.SetOutput(origOutput)
 	}
 	encrypt := fs.Bool("encrypt", false, "encrypt payload")
 	decrypt := fs.Bool("decrypt", false, "decrypt payload")
@@ -50,7 +52,6 @@ func main() {
 	ageIdentityFileFlag := fs.String("age-identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			fmt.Fprint(os.Stdout, usage.String())
 			return
 		}
 		fmt.Fprintf(os.Stderr, "usage: expected --encrypt or --decrypt\n")

--- a/main.go
+++ b/main.go
@@ -39,11 +39,8 @@ func main() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stdout, "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
-		origOutput := fs.Output()
-		fs.SetOutput(os.Stdout)
+		fmt.Fprintf(fs.Output(), "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
 		fs.PrintDefaults()
-		fs.SetOutput(origOutput)
 	}
 	encrypt := fs.Bool("encrypt", false, "encrypt payload")
 	decrypt := fs.Bool("decrypt", false, "decrypt payload")
@@ -52,6 +49,10 @@ func main() {
 	ageIdentityFileFlag := fs.String("age-identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			orig := fs.Output()
+			fs.SetOutput(os.Stdout)
+			fs.Usage()
+			fs.SetOutput(orig)
 			return
 		}
 		fmt.Fprintf(os.Stderr, "usage: expected --encrypt or --decrypt\n")

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	var usage bytes.Buffer
 	fs.SetOutput(&usage)
 	fs.Usage = func() {
-		fmt.Fprintf(&usage, "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
+		fmt.Fprintf(fs.Output(), "Usage: %s [--encrypt | --decrypt] [options]\n", os.Args[0])
 		fs.PrintDefaults()
 	}
 	encrypt := fs.Bool("encrypt", false, "encrypt payload")

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -1,0 +1,16 @@
+exec tofu-age-encryption --help
+cmp stdout stdout.txt
+! stderr .
+
+-- stdout.txt --
+Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
+  -age-identity-file string
+    	age identity file
+  -age-recipient string
+    	age recipient
+  -decrypt
+    	decrypt payload
+  -encrypt
+    	encrypt payload
+  -version
+    	print version


### PR DESCRIPTION
## Summary
- show usage text and exit 0 when `--help` is used
- add testscript coverage for the help flag

## Testing
- `go vet ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb9c77b3788326b341bbf8e31b642e