### PR TITLE
Add external key provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tofu-age-encryption
 
-tofu-age-encryption provides an external encryption method for [OpenTofu](https://opentofu.org/) using [age](https://age-encryption.org/).
+tofu-age-encryption provides an external encryption method and key provider for [OpenTofu](https://opentofu.org/) using [age](https://age-encryption.org/).
 
 OpenTofu encrypts state with a symmetric key derived from a shared passphrase that every operator must share and rotate together. This project replaces that workflow with age's asymmetric key pairs so operators can keep private keys, specify their own recipients, and rotate access without redistributing a secret.
 
@@ -52,4 +52,34 @@ output "pet" {
 ```sh
 $ tofu init
 $ tofu apply
+```
+
+## External key provider
+
+`tofu-age-encryption` can also act as an external key provider. This allows you to use built-in encryption methods like `aes_gcm` while storing the encryption key encrypted for your age recipients.
+
+Configure OpenTofu to use the key provider:
+
+```hcl
+terraform {
+  encryption {
+    key_provider "external" "age" {
+      command = ["tofu-age-encryption", "--key-provider"]
+    }
+
+    method "aes_gcm" "example" {
+      keys = key_provider.external.age
+    }
+
+    state {
+      method = method.aes_gcm.example
+      enforced = true
+    }
+
+    plan {
+      method = method.aes_gcm.example
+      enforced = true
+    }
+  }
+}
 ```

--- a/testdata/no-args-error.txtar
+++ b/testdata/no-args-error.txtar
@@ -4,4 +4,4 @@ cmp stderr stderr.txt
 
 -- stdout.json --
 -- stderr.txt --
-usage: expected --encrypt or --decrypt
+usage: expected --encrypt or --decrypt or --key-provider

--- a/testdata/tofu-external-key-provider.txtar
+++ b/testdata/tofu-external-key-provider.txtar
@@ -1,5 +1,4 @@
 env TF_INPUT=false
-env TF_INPUT=false
 env TF_CLI_ARGS=-no-color
 env AGE_RECIPIENT=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
 env AGE_IDENTITY_FILE=$WORK/key.txt

--- a/testdata/tofu-external-key-provider.txtar
+++ b/testdata/tofu-external-key-provider.txtar
@@ -1,0 +1,93 @@
+env TF_INPUT=false
+env TF_INPUT=false
+env TF_CLI_ARGS=-no-color
+env AGE_RECIPIENT=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+env AGE_IDENTITY_FILE=$WORK/key.txt
+
+exec tofu init
+cmp stdout init-stdout.txt
+cmp stderr init-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-1-stdout.txt
+cmp stderr apply-1-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-2-stdout.txt
+cmp stderr apply-2-stderr.txt
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- init-stdout.txt --
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+-- init-stderr.txt --
+-- apply-1-stdout.txt --
+
+Changes to Outputs:
+  + foo = "bar"
+
+You can apply this plan to save these new output values to the OpenTofu
+state, without changing any real infrastructure.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-1-stderr.txt --
+-- apply-2-stdout.txt --
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-2-stderr.txt --
+-- main.tf --
+terraform {
+  encryption {
+    key_provider "external" "age" {
+      command = ["tofu-age-encryption", "--key-provider"]
+    }
+
+    method "aes_gcm" "example" {
+      keys = key_provider.external.age
+    }
+
+    state {
+      method = method.aes_gcm.example
+      enforced = true
+    }
+
+    plan {
+      method = method.aes_gcm.example
+      enforced = true
+    }
+  }
+}
+
+output "foo" {
+  value = "bar"
+}
+


### PR DESCRIPTION
## Summary
- support OpenTofu external key provider protocol with `--key-provider`
- document key provider usage and example configuration
- add integration test for external key provider

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb9c4b179c8326bc43bb45dd8d84dd