### PR TITLE
feat: add age path override flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,13 @@ type Output struct {
 func main() {
 	ctx := context.Background()
 
+	ageProgram := AgeProgram
+	if ageProgram == "" || ageProgram == "age" {
+		if path, err := exec.LookPath("age"); err == nil {
+			ageProgram = path
+		}
+	}
+
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	encrypt := fs.Bool("encrypt", false, "encrypt payload")
@@ -43,6 +50,7 @@ func main() {
 	versionFlag := fs.Bool("version", false, "print version")
 	ageRecipientFlag := fs.String("age-recipient", os.Getenv("AGE_RECIPIENT"), "age recipient")
 	ageIdentityFileFlag := fs.String("age-identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
+	ageProgramFlag := fs.String("age-path", ageProgram, "path to age binary")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "usage: expected --encrypt or --decrypt\n")
 		os.Exit(1)
@@ -61,12 +69,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ageProgram := AgeProgram
-	if ageProgram == "" || ageProgram == "age" {
-		if path, err := exec.LookPath("age"); err == nil {
-			ageProgram = path
-		}
-	}
+	ageProgram = *ageProgramFlag
 
 	header := Header{
 		"OpenTofu-External-Encryption-Method",

--- a/testdata/age-missing-decrypt.txtar
+++ b/testdata/age-missing-decrypt.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! exec sh -c 'cmd=$(command -v tofu-age-encryption); PATH=/nonexistent "$cmd" --decrypt'
+! tofu-age-encryption --decrypt --age-path /nonexistent
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 
@@ -9,4 +9,4 @@ cmp stderr stderr.txt
 -- stdout.txt --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to decrypt payload: failed to decrypt payload with age: exec: "age": executable file not found in $PATH
+Failed to decrypt payload: failed to decrypt payload with age: fork/exec /nonexistent: no such file or directory

--- a/testdata/age-missing-encrypt.txtar
+++ b/testdata/age-missing-encrypt.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! exec sh -c 'cmd=$(command -v tofu-age-encryption); PATH=/nonexistent "$cmd" --encrypt'
+! tofu-age-encryption --encrypt --age-path /nonexistent
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 
@@ -9,4 +9,4 @@ cmp stderr stderr.txt
 -- stdout.txt --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to encrypt payload: failed to encrypt payload with age: exec: "age": executable file not found in $PATH
+Failed to encrypt payload: failed to encrypt payload with age: fork/exec /nonexistent: no such file or directory


### PR DESCRIPTION
## Summary
- add `--age-path` CLI flag to override age binary location
- use new flag in missing-age tests instead of modifying PATH
- resolve default age binary path before parsing flags

## Testing
- `go fmt ./...`
- `go mod download`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build ./...`
- `CI=1 go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bba06a0cec8326911820a96deb464f