### PR TITLE
Update help flag test data to fix CI

### DIFF
--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -6,7 +6,9 @@ cmp stdout stdout.txt
 Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
   -age-identity-file string
     	age identity file
-  -age-recipient string
+  -age-path string
+    	path to age binary (default "/usr/bin/age")
+  -age-recipient value
     	age recipient
   -decrypt
     	decrypt payload


### PR DESCRIPTION
## Summary
- refresh `help`-flag test expectations for new `-age-path` option and updated `-age-recipient` flag type

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbb770b3dc8326b35e139623fd8697