### PR TITLE
Add recipients file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 
     - `AGE_IDENTITY_FILE`: path to your age identity file
     - `AGE_RECIPIENT`: comma-separated list of age recipients
+    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
 
    CLI flags:
 
     - `--age-identity-file`: path to your age identity file
     - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
+    - `--age-recipients-file`: path to a file with newline-separated age recipients
 
 2. Configure OpenTofu to use the external method:
 

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -10,6 +10,8 @@ Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
     	path to age binary (default "/usr/bin/age")
   -age-recipient value
     	age recipient
+  -age-recipients-file string
+    	age recipients file
   -decrypt
     	decrypt payload
   -encrypt

--- a/testdata/tofu-external-flags-recipients-file.txtar
+++ b/testdata/tofu-external-flags-recipients-file.txtar
@@ -1,0 +1,90 @@
+env TF_INPUT=false
+env TF_INPUT=false
+env TF_CLI_ARGS=-no-color
+
+exec tofu init
+cmp stdout init-stdout.txt
+cmp stderr init-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-1-stdout.txt
+cmp stderr apply-1-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-2-stdout.txt
+cmp stderr apply-2-stderr.txt
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- recipients.txt --
+age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+
+-- init-stdout.txt --
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+-- init-stderr.txt --
+-- apply-1-stdout.txt --
+
+Changes to Outputs:
+  + foo = "bar"
+
+You can apply this plan to save these new output values to the OpenTofu
+state, without changing any real infrastructure.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-1-stderr.txt --
+-- apply-2-stdout.txt --
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-2-stderr.txt --
+-- main.tf --
+terraform {
+  encryption {
+    method "external" "age" {
+      encrypt_command = ["tofu-age-encryption", "--encrypt", "--age-recipients-file", "recipients.txt"]
+      decrypt_command = ["tofu-age-encryption", "--decrypt", "--age-identity-file", "key.txt"]
+    }
+
+    state {
+      method = method.external.age
+      enforced = true
+    }
+
+    plan {
+      method = method.external.age
+      enforced = true
+    }
+  }
+}
+
+output "foo" {
+  value = "bar"
+}

--- a/testdata/tofu-external-recipients-file.txtar
+++ b/testdata/tofu-external-recipients-file.txtar
@@ -1,0 +1,91 @@
+env TF_INPUT=false
+env TF_INPUT=false
+env TF_CLI_ARGS=-no-color
+env AGE_RECIPIENTS_FILE=$WORK/recipients.txt
+env AGE_IDENTITY_FILE=$WORK/key.txt
+exec tofu init
+cmp stdout init-stdout.txt
+cmp stderr init-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-1-stdout.txt
+cmp stderr apply-1-stderr.txt
+
+exec tofu apply -auto-approve -lock=false
+cmp stdout apply-2-stdout.txt
+cmp stderr apply-2-stderr.txt
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- recipients.txt --
+age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+
+-- init-stdout.txt --
+
+Initializing the backend...
+
+Initializing provider plugins...
+
+OpenTofu has been successfully initialized!
+
+You may now begin working with OpenTofu. Try running "tofu plan" to see
+any changes that are required for your infrastructure. All OpenTofu commands
+should now work.
+
+If you ever set or change modules or backend configuration for OpenTofu,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+-- init-stderr.txt --
+-- apply-1-stdout.txt --
+
+Changes to Outputs:
+  + foo = "bar"
+
+You can apply this plan to save these new output values to the OpenTofu
+state, without changing any real infrastructure.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-1-stderr.txt --
+-- apply-2-stdout.txt --
+
+No changes. Your infrastructure matches the configuration.
+
+OpenTofu has compared your real infrastructure against your configuration and
+found no differences, so no changes are needed.
+
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+foo = "bar"
+-- apply-2-stderr.txt --
+-- main.tf --
+terraform {
+  encryption {
+    method "external" "age" {
+      encrypt_command = ["tofu-age-encryption", "--encrypt"]
+      decrypt_command = ["tofu-age-encryption", "--decrypt"]
+    }
+
+    state {
+      method = method.external.age
+      enforced = true
+    }
+
+    plan {
+      method = method.external.age
+      enforced = true
+    }
+  }
+}
+
+output "foo" {
+  value = "bar"
+}


### PR DESCRIPTION
## Summary
- allow specifying recipients via `--age-recipients-file` flag or `AGE_RECIPIENTS_FILE` env var
- document recipients file usage
- test recipients file via flag and env
- handle usage message printing errors

## Testing
- `go vet ./...`
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbc671002083268c61d0ff8c688090