### PR TITLE
feat: support SOPS env aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
    - `AGE_IDENTITY_FILE`: path to your age identity file
    - `AGE_RECIPIENT`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
+
+   The following `SOPS_`-prefixed variables are also supported as aliases for compatibility with tools that expect them:
+
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
-   - `SOPS_AGE_KEY`: alias for `AGE_IDENTITY_FILE` containing the age identity
-   - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_FILE` via shell command output
+   - `SOPS_AGE_KEY`: age identity string
+   - `SOPS_AGE_KEY_CMD`: command whose output is the age identity
    - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
 
    CLI flags:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 
    Environment variables:
 
-    - `AGE_IDENTITY_FILE`: path to your age identity file
-    - `AGE_RECIPIENT`: comma-separated list of age recipients
-    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
+   - `AGE_IDENTITY_FILE`: path to your age identity file
+   - `AGE_RECIPIENT`: comma-separated list of age recipients
+   - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
+   - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
+   - `SOPS_AGE_KEY`: alias for `AGE_IDENTITY_FILE` containing the age identity
+   - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_FILE` via shell command output
+   - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
 
    CLI flags:
 

--- a/testdata/sops-age-env.txtar
+++ b/testdata/sops-age-env.txtar
@@ -1,0 +1,21 @@
+env SOPS_AGE_RECIPIENTS=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+env SOPS_AGE_KEY_FILE=$WORK/key.txt
+exec sh -c 'tofu-age-encryption --encrypt <plain.json | tail -n +2 >cipher.json'
+stdout ''
+stderr ''
+exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- plain.json --
+{"payload":"c2VjcmV0"}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --

--- a/testdata/sops-age-key-cmd.txtar
+++ b/testdata/sops-age-key-cmd.txtar
@@ -1,0 +1,17 @@
+env SOPS_AGE_KEY_CMD='cat $WORK/key.txt'
+exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --

--- a/testdata/sops-age-key.txtar
+++ b/testdata/sops-age-key.txtar
@@ -1,0 +1,12 @@
+env SOPS_AGE_KEY=AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --


### PR DESCRIPTION
## Summary
- support SOPS_AGE_* environment variables alongside existing AGE_* vars
- document SOPS aliases in README
- add tests covering SOPS environment variable support

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc73675c448326b2a27f9293e50a6e