### PR TITLE
docs: add markdown prettier instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,14 @@ Format code with:
 $ go fmt ./...
 ```
 
+## Coding Style
+
+Format Markdown files with:
+
+```sh
+$ prettier --write *.md
+```
+
 ## Code Quality
 
 Run vet and static analysis tools before committing:


### PR DESCRIPTION
## Summary
- document formatting markdown files with `prettier --write *.md`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc777f05f88326a54590ba30203df0