### PR TITLE
Add AGE_IDENTITY_COMMAND with aliases for age identity command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
    Environment variables:
 
    - `AGE_IDENTITY_FILE`: path to your age identity file
+   - `AGE_IDENTITY_COMMAND` (alias: `AGE_IDENTITY_CMD`): command whose output is the age identity
    - `AGE_RECIPIENT`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
 
@@ -18,7 +19,7 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
    - `SOPS_AGE_KEY`: age identity string
-   - `SOPS_AGE_KEY_CMD`: command whose output is the age identity
+   - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_COMMAND`
    - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
 
    CLI flags:

--- a/testdata/age-identity-cmd.txtar
+++ b/testdata/age-identity-cmd.txtar
@@ -1,0 +1,17 @@
+env AGE_IDENTITY_CMD='cat $WORK/key.txt'
+exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --

--- a/testdata/age-identity-command.txtar
+++ b/testdata/age-identity-command.txtar
@@ -1,0 +1,17 @@
+env AGE_IDENTITY_COMMAND='cat $WORK/key.txt'
+exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --


### PR DESCRIPTION
## Summary
- Support AGE_IDENTITY_COMMAND for providing an age identity via command
- Accept AGE_IDENTITY_CMD and SOPS_AGE_KEY_CMD as aliases
- Document new environment variables and add tests for new aliases

## Testing
- `go mod download`
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc77ee717c832690152bf044bf1c5d