### PR TITLE
test: verify state after apply

### DIFF
--- a/testdata/tofu-external-flags-multi.txtar
+++ b/testdata/tofu-external-flags-multi.txtar
@@ -4,8 +4,16 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-external-flags-recipients-file.txtar
+++ b/testdata/tofu-external-flags-recipients-file.txtar
@@ -5,8 +5,16 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-external-flags.txtar
+++ b/testdata/tofu-external-flags.txtar
@@ -5,8 +5,16 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-external-multi.txtar
+++ b/testdata/tofu-external-multi.txtar
@@ -6,8 +6,16 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-external-recipients-file.txtar
+++ b/testdata/tofu-external-recipients-file.txtar
@@ -6,8 +6,16 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-external-wrong-key.txtar
+++ b/testdata/tofu-external-wrong-key.txtar
@@ -6,6 +6,10 @@ env AGE_IDENTITY_FILE=$WORK/key-a.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 env AGE_IDENTITY_FILE=$WORK/key-b.txt
 

--- a/testdata/tofu-external.txtar
+++ b/testdata/tofu-external.txtar
@@ -7,8 +7,16 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- key.txt --
 # created: 2025-09-05T17:27:52-07:00

--- a/testdata/tofu-pbkdf2-aes_gcm.txtar
+++ b/testdata/tofu-pbkdf2-aes_gcm.txtar
@@ -5,8 +5,16 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+! stdout foo
+! stdout bar
 
 -- main.tf --
 terraform {

--- a/testdata/tofu-unencrypted.txtar
+++ b/testdata/tofu-unencrypted.txtar
@@ -1,0 +1,21 @@
+env TF_INPUT=false
+env TF_CLI_ARGS=-no-color
+
+exec tofu init
+
+exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+stdout foo
+stdout bar
+
+exec tofu apply -auto-approve -lock=false
+exec python -m json.tool terraform.tfstate
+exec cat terraform.tfstate
+stdout foo
+stdout bar
+
+-- main.tf --
+output "foo" {
+  value = "bar"
+}


### PR DESCRIPTION
## Summary
- extend tofu apply tests to verify terraform.tfstate is valid JSON without plaintext
- add unencrypted apply test to confirm plaintext values appear

## Testing
- `go mod download`
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc78452b7883269e4f20a8862eecd7