### PR TITLE
Add input/output file flags for standalone use

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
     - `--age-identity-file`: path to your age identity file
     - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
     - `--age-recipients-file`: path to a file with newline-separated age recipients
+    - `--input-file`: read input from file instead of stdin
+    - `--output-file`: write output to file instead of stdout
 
 2. Configure OpenTofu to use the external method:
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,8 @@ func main() {
 	ageRecipientsFileFlag := fs.String("age-recipients-file", os.Getenv("AGE_RECIPIENTS_FILE"), "age recipients file")
 	ageIdentityFileFlag := fs.String("age-identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
 	ageProgramFlag := fs.String("age-path", ageProgram, "path to age binary")
+	inputFileFlag := fs.String("input-file", "", "read input from file instead of stdin")
+	outputFileFlag := fs.String("output-file", "", "write output to file instead of stdout")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			orig := fs.Output()
@@ -115,26 +117,54 @@ func main() {
 
 	ageProgram = *ageProgramFlag
 
+	// Configure input reader.
+	in := io.Reader(os.Stdin)
+	inputDesc := "stdin"
+	if *inputFileFlag != "" {
+		f, err := os.Open(*inputFileFlag)
+		if err != nil {
+			log.Fatalf("Failed to open input file: %v", err)
+		}
+		defer f.Close()
+		in = f
+		inputDesc = "input file"
+	}
+
+	// Configure output writer.
+	out := io.Writer(os.Stdout)
+	outputDesc := "stdout"
+	if *outputFileFlag != "" {
+		f, err := os.OpenFile(*outputFileFlag, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+		if err != nil {
+			log.Fatalf("Failed to open output file: %v", err)
+		}
+		defer f.Close()
+		out = f
+		outputDesc = "output file"
+	}
+
 	header := Header{
 		"OpenTofu-External-Encryption-Method",
 		1,
 	}
-	marshalledHeader, err := json.Marshal(header)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-	_, err = os.Stdout.Write(append(marshalledHeader, []byte("\n")...))
-	if err != nil {
-		log.Fatalf("Failed to write output: %v", err)
+	if err := json.NewEncoder(out).Encode(header); err != nil {
+		log.Fatalf("Failed to write %s: %v", outputDesc, err)
 	}
 
-	input, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		log.Fatalf("Failed to read stdin: %v", err)
-	}
+	dec := json.NewDecoder(in)
 	var inputData Input
-	if err = json.Unmarshal(input, &inputData); err != nil {
-		log.Fatalf("Failed to parse stdin: %v", err)
+	var first json.RawMessage
+	if err := dec.Decode(&first); err != nil {
+		log.Fatalf("Failed to read %s: %v", inputDesc, err)
+	}
+	var hdr Header
+	if err := json.Unmarshal(first, &hdr); err == nil && hdr.Magic == header.Magic {
+		if err := dec.Decode(&first); err != nil {
+			log.Fatalf("Failed to read %s: %v", inputDesc, err)
+		}
+	}
+	if err := json.Unmarshal(first, &inputData); err != nil {
+		log.Fatalf("Failed to parse %s: %v", inputDesc, err)
 	}
 
 	ageIdentityFile := *ageIdentityFileFlag
@@ -162,7 +192,10 @@ func main() {
 		}
 	}
 
-	var outputPayload []byte
+	var (
+		outputPayload []byte
+		err           error
+	)
 	if *encrypt {
 		outputPayload, err = ageEncryptPayload(ctx, ageProgram, []string(ageRecipients), *ageRecipientsFileFlag, inputData.Payload)
 		if err != nil {
@@ -183,9 +216,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to stringify output: %v", err)
 	}
-	_, err = os.Stdout.Write(append(outputData, []byte("\n")...))
-	if err != nil {
-		log.Fatalf("Failed to write output: %v", err)
+	if _, err = fmt.Fprintln(out, string(outputData)); err != nil {
+		log.Fatalf("Failed to write %s: %v", outputDesc, err)
 	}
 }
 

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -16,5 +16,9 @@ Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
     	decrypt payload
   -encrypt
     	encrypt payload
+  -input-file string
+    	read input from file instead of stdin
+  -output-file string
+    	write output to file instead of stdout
   -version
     	print version

--- a/testdata/input-output-file-flags.txtar
+++ b/testdata/input-output-file-flags.txtar
@@ -1,0 +1,19 @@
+exec tofu-age-encryption --encrypt --age-recipient age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt --input-file input.json --output-file encrypted.json
+stdout ''
+stderr ''
+exec tofu-age-encryption --decrypt --age-identity-file key.txt --input-file encrypted.json --output-file decrypted.json
+stdout ''
+stderr ''
+cmp decrypted.json expected-decrypted.json
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- input.json --
+{"payload":"c2FtcGxlIHRleHQ="}
+
+-- expected-decrypted.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2FtcGxlIHRleHQ="}

--- a/testdata/invalid-json-input.txtar
+++ b/testdata/invalid-json-input.txtar
@@ -8,4 +8,4 @@ cmp stderr stderr.txt
 -- stdout.txt --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to parse stdin: unexpected end of JSON input
+Failed to read stdin: unexpected EOF


### PR DESCRIPTION
## Summary
- allow reading from an input file and writing to an output file instead of stdin/stdout
- document new `--input-file` and `--output-file` flags
- test encrypting and decrypting via file flags
- refactor I/O setup to use common reader/writer abstractions and remove duplicated code
- always emit and accept the OpenTofu handshake header for any I/O mode

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc77b0b40c8326a2aeb08f1fbf06cb