### PR TITLE
docs: document test binary dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,17 @@ sudo apt-get install -y tofu
 $ go mod download
 ```
 
+## Test Environment
+
+The test suite expects these binaries to be available in the system `PATH`:
+
+- `age`
+- `tofu`
+- `sh`
+- `tail`
+- `sed`
+- `cat`
+
 ## Testing
 
 Run all tests with:


### PR DESCRIPTION
## Summary
- note external binaries required by tests, including core utilities and OpenTofu

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ba773bc83268773edcea43fc002