### PR TITLE
Avoid temp file by piping age identity

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -223,6 +224,9 @@ func ageDecryptPayload(ctx context.Context, ageProgram string, identityFile, ide
 	if identityFile != "" {
 		args = append(args, "--identity", identityFile)
 	} else if identity != "" {
+		if runtime.GOOS == "windows" {
+			return nil, errors.New("identity pipes not supported on Windows; use --age-identity-file")
+		}
 		r, w, err := os.Pipe()
 		if err != nil {
 			return nil, fmt.Errorf("pipe identity: %w", err)

--- a/main.go
+++ b/main.go
@@ -238,7 +238,7 @@ func ageDecryptPayload(ctx context.Context, ageProgram string, identityFile, ide
 		}
 		extra = append(extra, r)
 		fd := 3 + len(extra) - 1
-		args = append(args, "--identity", fmt.Sprintf("/proc/self/fd/%d", fd))
+		args = append(args, "--identity", fmt.Sprintf("/dev/fd/%d", fd)) // works on Linux and macOS
 		defer r.Close()
 	}
 


### PR DESCRIPTION
## Summary
- read age identity via in-memory pipe instead of creating temporary file
- thread identity data through `ageDecryptPayload`

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b45b04083269875434c17b2c5a9