### PR TITLE
test: avoid shell redirection in test scripts

### DIFF
--- a/testdata/age-identity-cmd.txtar
+++ b/testdata/age-identity-cmd.txtar
@@ -1,5 +1,5 @@
 env AGE_IDENTITY_CMD='cat $WORK/key.txt'
-exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 

--- a/testdata/age-identity-command.txtar
+++ b/testdata/age-identity-command.txtar
@@ -1,5 +1,5 @@
 env AGE_IDENTITY_COMMAND='cat $WORK/key.txt'
-exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 

--- a/testdata/decrypt-missing-identity.txtar
+++ b/testdata/decrypt-missing-identity.txtar
@@ -1,6 +1,6 @@
 env AGE_IDENTITY_FILE=missing
 
-! exec sh -c 'tofu-age-encryption --decrypt <input.json'
+! exec tofu-age-encryption --decrypt --input-file input.json
 cmp stdout stdout.json
 cmp stderr stderr.txt
 

--- a/testdata/decrypt-wrong-identity.txtar
+++ b/testdata/decrypt-wrong-identity.txtar
@@ -1,5 +1,5 @@
 env AGE_IDENTITY_FILE=key-b.txt
-! exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+! exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.json
 cmp stderr stderr.txt
 

--- a/testdata/sops-age-env.txtar
+++ b/testdata/sops-age-env.txtar
@@ -1,9 +1,11 @@
 env SOPS_AGE_RECIPIENTS=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
 env SOPS_AGE_KEY_FILE=$WORK/key.txt
-exec sh -c 'tofu-age-encryption --encrypt <plain.json | tail -n +2 >cipher.json'
+exec tofu-age-encryption --encrypt --input-file plain.json --output-file cipher-all.json
 stdout ''
 stderr ''
-exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+exec tail -n +2 cipher-all.json
+cp stdout cipher.json
+exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 

--- a/testdata/sops-age-key-cmd.txtar
+++ b/testdata/sops-age-key-cmd.txtar
@@ -1,5 +1,5 @@
 env SOPS_AGE_KEY_CMD='cat $WORK/key.txt'
-exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 

--- a/testdata/sops-age-key.txtar
+++ b/testdata/sops-age-key.txtar
@@ -1,5 +1,5 @@
 env SOPS_AGE_KEY=AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
-exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
+exec tofu-age-encryption --decrypt --input-file cipher.json
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 


### PR DESCRIPTION
## Summary
- replace shell redirection with `--input-file`/`--output-file` flags in tests
- rework sops age env test to avoid sh dependence

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7f2449f88326befc9693600faf13