### PR TITLE
Add CLI flags for age identity string and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,25 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 1. Provide the age recipient and identity file using either environment variables or CLI flags:
 
    Environment variables:
-
    - `AGE_IDENTITY_FILE`: path to your age identity file
    - `AGE_IDENTITY_COMMAND` (alias: `AGE_IDENTITY_CMD`): command whose output is the age identity
    - `AGE_RECIPIENT`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
 
    The following `SOPS_`-prefixed variables are also supported as aliases for compatibility with tools that expect them:
-
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
    - `SOPS_AGE_KEY`: age identity string
    - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_COMMAND`
    - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
 
    CLI flags:
-
-    - `--age-identity-file`: path to your age identity file
-    - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
-    - `--age-recipients-file`: path to a file with newline-separated age recipients
-    - `--input-file`: read input from file instead of stdin
-    - `--output-file`: write output to file instead of stdout
+   - `--age-identity-file`: path to your age identity file
+   - `--age-identity`: age identity string
+   - `--age-identity-command`: command whose output is the age identity
+   - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
+   - `--age-recipients-file`: path to a file with newline-separated age recipients
+   - `--input-file`: read input from file instead of stdin
+   - `--output-file`: write output to file instead of stdout
 
 2. Configure OpenTofu to use the external method:
 

--- a/testdata/age-identity-command-flag.txtar
+++ b/testdata/age-identity-command-flag.txtar
@@ -1,0 +1,20 @@
+exec chmod +x keycmd.sh
+exec tofu-age-encryption --decrypt --age-identity-command 'sh keycmd.sh' --input-file cipher.json
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --
+-- keycmd.sh --
+#!/bin/sh
+cat key.txt

--- a/testdata/age-identity-flag.txtar
+++ b/testdata/age-identity-flag.txtar
@@ -1,0 +1,11 @@
+exec tofu-age-encryption --decrypt --age-identity AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N --input-file cipher.json
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -4,6 +4,10 @@ cmp stdout help.txt
 
 -- help.txt --
 Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
+  -age-identity string
+    	age identity string
+  -age-identity-command string
+    	command whose output is the age identity
   -age-identity-file string
     	age identity file
   -age-path string


### PR DESCRIPTION
## Summary
- add `--age-identity` and `--age-identity-command` flags to mirror env vars
- document new flags and update help output
- test new flags for direct key and command-based key usage

## Testing
- `go fmt ./...`
- `prettier --write *.md`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc805b38b48326bd4378336cb11a83