### PR TITLE
Validate age inputs before execution

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,6 +223,9 @@ func main() {
 }
 
 func ageEncryptPayload(ctx context.Context, ageProgram string, pubkeys []string, recipientsFile string, payload []byte) ([]byte, error) {
+	if recipientsFile == "" && len(pubkeys) == 0 {
+		return nil, errors.New("no recipients specified")
+	}
 	args := []string{"--encrypt"}
 	if recipientsFile != "" {
 		args = append(args, "--recipients-file", recipientsFile)
@@ -251,6 +254,9 @@ func ageEncryptPayload(ctx context.Context, ageProgram string, pubkeys []string,
 }
 
 func ageDecryptPayload(ctx context.Context, ageProgram string, identityFile, identity string, payload []byte) ([]byte, error) {
+	if identityFile == "" && identity == "" {
+		return nil, errors.New("no identity specified")
+	}
 	args := []string{"--decrypt"}
 	var extra []*os.File
 	if identityFile != "" {

--- a/testdata/age-missing-encrypt.txtar
+++ b/testdata/age-missing-encrypt.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! tofu-age-encryption --encrypt --age-path /nonexistent
+! tofu-age-encryption --encrypt --age-path /nonexistent --age-recipient dummy
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 

--- a/testdata/decrypt-no-identity.txtar
+++ b/testdata/decrypt-no-identity.txtar
@@ -1,0 +1,12 @@
+stdin input.json
+! tofu-age-encryption --decrypt
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+-- stderr.txt --
+Failed to decrypt payload: no identity specified

--- a/testdata/encrypt-no-recipient.txtar
+++ b/testdata/encrypt-no-recipient.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! tofu-age-encryption --decrypt --age-path /nonexistent --age-identity-file dummy
+! tofu-age-encryption --encrypt
 cmp stdout stdout.txt
 cmp stderr stderr.txt
 
@@ -9,4 +9,4 @@ cmp stderr stderr.txt
 -- stdout.txt --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to decrypt payload: failed to decrypt payload with age: fork/exec /nonexistent: no such file or directory
+Failed to encrypt payload: no recipients specified


### PR DESCRIPTION
## Summary
- prevent running age when no recipients are supplied for encryption
- prevent running age when no identity is supplied for decryption
- add tests for missing recipients/identity and update existing test scripts

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc8152194c8326ab2564b77f4433dc