### PR TITLE
Remove shell dependency for key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,23 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 1. Provide the age recipient and identity file using either environment variables or CLI flags:
 
    Environment variables:
-
    - `AGE_IDENTITY_FILE`: path to your age identity file
    - `AGE_IDENTITY_COMMAND` (alias: `AGE_IDENTITY_CMD`): command whose output is the age identity
    - `AGE_RECIPIENT`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
 
    The following `SOPS_`-prefixed variables are also supported as aliases for compatibility with tools that expect them:
-
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
    - `SOPS_AGE_KEY`: age identity string
    - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_COMMAND`
    - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
 
    CLI flags:
-
-    - `--age-identity-file`: path to your age identity file
-    - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
-    - `--age-recipients-file`: path to a file with newline-separated age recipients
-    - `--input-file`: read input from file instead of stdin
-    - `--output-file`: write output to file instead of stdout
+   - `--age-identity-file`: path to your age identity file
+   - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
+   - `--age-recipients-file`: path to a file with newline-separated age recipients
+   - `--input-file`: read input from file instead of stdin
+   - `--output-file`: write output to file instead of stdout
 
 2. Configure OpenTofu to use the external method:
 

--- a/testdata/age-identity-cmd.txtar
+++ b/testdata/age-identity-cmd.txtar
@@ -1,4 +1,4 @@
-env AGE_IDENTITY_CMD='cat $WORK/key.txt'
+env AGE_IDENTITY_CMD='cat key.txt'
 exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
 cmp stdout stdout.txt
 cmp stderr stderr.txt

--- a/testdata/age-identity-command.txtar
+++ b/testdata/age-identity-command.txtar
@@ -1,4 +1,4 @@
-env AGE_IDENTITY_COMMAND='cat $WORK/key.txt'
+env AGE_IDENTITY_COMMAND='cat key.txt'
 exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
 cmp stdout stdout.txt
 cmp stderr stderr.txt

--- a/testdata/sops-age-key-cmd.txtar
+++ b/testdata/sops-age-key-cmd.txtar
@@ -1,4 +1,4 @@
-env SOPS_AGE_KEY_CMD='cat $WORK/key.txt'
+env SOPS_AGE_KEY_CMD='cat key.txt'
 exec sh -c 'tofu-age-encryption --decrypt <cipher.json'
 cmp stdout stdout.txt
 cmp stderr stderr.txt


### PR DESCRIPTION
## Summary
- parse key commands with a small stdlib parser instead of the deprecated shlex module
- simplify `AGE_IDENTITY_COMMAND` documentation

## Testing
- `prettier --write *.md`
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc7f5c2b28832690027aca9f51c27f