### PR TITLE
Simplify tests by dropping jq dependency

### DIFF
--- a/testdata/tofu-external-flags-multi.txtar
+++ b/testdata/tofu-external-flags-multi.txtar
@@ -4,13 +4,11 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external-flags-recipients-file.txtar
+++ b/testdata/tofu-external-flags-recipients-file.txtar
@@ -5,13 +5,11 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external-flags.txtar
+++ b/testdata/tofu-external-flags.txtar
@@ -5,13 +5,11 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external-multi.txtar
+++ b/testdata/tofu-external-multi.txtar
@@ -6,13 +6,11 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external-recipients-file.txtar
+++ b/testdata/tofu-external-recipients-file.txtar
@@ -6,13 +6,11 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external-wrong-key.txtar
+++ b/testdata/tofu-external-wrong-key.txtar
@@ -6,7 +6,6 @@ env AGE_IDENTITY_FILE=$WORK/key-a.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-external.txtar
+++ b/testdata/tofu-external.txtar
@@ -7,13 +7,11 @@ env AGE_IDENTITY_FILE=$WORK/key.txt
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-pbkdf2-aes_gcm.txtar
+++ b/testdata/tofu-pbkdf2-aes_gcm.txtar
@@ -5,13 +5,11 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 ! stdout foo
 ! stdout bar

--- a/testdata/tofu-unencrypted.txtar
+++ b/testdata/tofu-unencrypted.txtar
@@ -4,13 +4,11 @@ env TF_CLI_ARGS=-no-color
 exec tofu init
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 stdout foo
 stdout bar
 
 exec tofu apply -auto-approve -lock=false
-exec python -m json.tool terraform.tfstate
 exec cat terraform.tfstate
 stdout foo
 stdout bar


### PR DESCRIPTION
## Summary
- remove jq requirement from development guide
- drop unnecessary jq invocations in test scripts

## Testing
- `npx prettier --write AGENTS.md`
- `go fmt ./...`
- `go vet ./...`
- `go mod download`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc82d58d388326ab9bc93f339ff096