### PR TITLE
Parse age recipients file upfront

### DIFF
--- a/testdata/tofu-external-flags-recipients-file.txtar
+++ b/testdata/tofu-external-flags-recipients-file.txtar
@@ -20,7 +20,9 @@ exec cat terraform.tfstate
 AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 
 -- recipients.txt --
+# first recipient
 age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+# end
 
 -- main.tf --
 terraform {

--- a/testdata/tofu-external-recipients-file.txtar
+++ b/testdata/tofu-external-recipients-file.txtar
@@ -21,7 +21,9 @@ exec cat terraform.tfstate
 AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 
 -- recipients.txt --
+# first recipient
 age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+# end
 
 -- main.tf --
 terraform {


### PR DESCRIPTION
## Summary
- inline recipients file parsing in `main.go`
- drop unit test and dedicated recipients parser file
- verify comment handling via updated testdata recipients files

## Testing
- `go fmt ./...`
- `go mod download`
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc8e4a7a288326989d3ae4e1e95abc