### PR TITLE
Merge age recipients from multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
    - `SOPS_AGE_KEY`: age identity string
    - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_COMMAND`
-   - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`
+   - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT` (values from both variables are merged; duplicates are ignored)
 
    CLI flags:
    - `--age-identity-file`: path to your age identity file

--- a/testdata/merge-age-envs.txtar
+++ b/testdata/merge-age-envs.txtar
@@ -1,0 +1,24 @@
+env AGE_RECIPIENT=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+env SOPS_AGE_RECIPIENTS=age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+env AGE_IDENTITY_FILE=$WORK/key2.txt
+exec tofu-age-encryption --encrypt --input-file plain.json --output-file cipher-all.json
+stdout ''
+stderr ''
+exec tail -n +2 cipher-all.json
+cp stdout cipher.json
+exec tofu-age-encryption --decrypt --input-file cipher.json
+cmp stdout stdout.txt
+cmp stderr stderr.txt
+
+-- plain.json --
+{"payload":"c2VjcmV0"}
+
+-- key2.txt --
+# created: 2025-09-06T20:25:14Z
+# public key: age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+AGE-SECRET-KEY-17Y29Y9E2XTJ6ZPZ6X3YNSE3NVREHJG64GFPYWNRF0MSU4L0E3V5Q84AFZH
+
+-- stdout.txt --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --


### PR DESCRIPTION
## Summary
- Collect age recipients from flags, env vars, and files
- Deduplicate age recipient list
- Document merged env var behavior and add regression test

## Testing
- `go fmt ./...`
- `prettier --write README.md`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bc98316430832690f34424cd81ea36