### PR TITLE
Check for missing age binary before execution

### DIFF
--- a/main.go
+++ b/main.go
@@ -308,6 +308,9 @@ func ageEncryptPayload(ctx context.Context, cfg *Config, payload []byte) ([]byte
 	if len(cfg.ageRecipients) == 0 {
 		return nil, errors.New("no recipients specified")
 	}
+	if _, err := exec.LookPath(cfg.ageProgram); err != nil {
+		return nil, fmt.Errorf("age program not found: %s", cfg.ageProgram)
+	}
 	recipientsFile, cleanup, err := writeTempRecipients(cfg.ageRecipients)
 	if err != nil {
 		return nil, fmt.Errorf("write recipients to temp file: %w", err)
@@ -338,6 +341,9 @@ func ageEncryptPayload(ctx context.Context, cfg *Config, payload []byte) ([]byte
 func ageDecryptPayload(ctx context.Context, cfg *Config, payload []byte) ([]byte, error) {
 	if cfg.ageIdentityFile == "" && cfg.ageIdentity == "" {
 		return nil, errors.New("no identity specified")
+	}
+	if _, err := exec.LookPath(cfg.ageProgram); err != nil {
+		return nil, fmt.Errorf("age program not found: %s", cfg.ageProgram)
 	}
 	args := []string{"--decrypt"}
 	var (

--- a/testdata/decrypt-age-program-missing.txtar
+++ b/testdata/decrypt-age-program-missing.txtar
@@ -14,4 +14,4 @@ AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 -- stdout.json --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to decrypt payload: failed to decrypt payload with age: fork/exec /missing/age: no such file or directory
+Failed to decrypt payload: age program not found: /missing/age

--- a/testdata/encrypt-age-program-missing.txtar
+++ b/testdata/encrypt-age-program-missing.txtar
@@ -12,4 +12,4 @@ age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
 -- stdout.json --
 {"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
-Failed to encrypt payload: failed to encrypt payload with age: fork/exec /missing/age: no such file or directory
+Failed to encrypt payload: age program not found: /missing/age


### PR DESCRIPTION
## Summary
- fail fast when configured age binary is missing
- update tests to expect clearer error message when age is absent

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bccbf2e2d483268ab85f256e08d724