### PR TITLE
Avoid emitting magic header on errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,9 +255,7 @@ func main() {
 		"OpenTofu-External-Encryption-Method",
 		1,
 	}
-	if err := json.NewEncoder(out).Encode(header); err != nil {
-		log.Fatalf("Failed to write %s: %v", outputDesc, err)
-	}
+	var buf bytes.Buffer
 
 	dec := json.NewDecoder(in)
 	var inputData Input
@@ -299,7 +297,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to stringify output: %v", err)
 	}
-	if _, err = fmt.Fprintln(out, string(outputData)); err != nil {
+	if err := json.NewEncoder(&buf).Encode(header); err != nil {
+		log.Fatalf("Failed to prepare output: %v", err)
+	}
+	if _, err = fmt.Fprintln(&buf, string(outputData)); err != nil {
+		log.Fatalf("Failed to prepare output: %v", err)
+	}
+	if _, err = io.Copy(out, &buf); err != nil {
 		log.Fatalf("Failed to write %s: %v", outputDesc, err)
 	}
 }

--- a/testdata/decrypt-age-program-missing.txtar
+++ b/testdata/decrypt-age-program-missing.txtar
@@ -12,6 +12,5 @@ AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 {"payload":"aGVsbG8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: failed to decrypt payload with age: fork/exec /missing/age: no such file or directory

--- a/testdata/decrypt-missing-age-identity-file-env.txtar
+++ b/testdata/decrypt-missing-age-identity-file-env.txtar
@@ -9,7 +9,6 @@ cmp stderr stderr.txt
 {"payload":"c2VjcmV0"}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: age: error: reading "/tmp/missing": failed to open file: open /tmp/missing: no such file or directory
 age: report unexpected or unhelpful errors at https://filippo.io/age/report

--- a/testdata/decrypt-no-identity.txtar
+++ b/testdata/decrypt-no-identity.txtar
@@ -7,6 +7,5 @@ cmp stderr stderr.txt
 {"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: no identity specified

--- a/testdata/decrypt-wrong-identity.txtar
+++ b/testdata/decrypt-wrong-identity.txtar
@@ -12,7 +12,6 @@ cmp stderr stderr.txt
 AGE-SECRET-KEY-19LDXPQ0ZFT5VRG2LT84470RAJ79QZU9HWJJ97LM7YF0KWX6GCGHSLEVXKZ
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: age: error: no identity matched any of the recipients
 age: report unexpected or unhelpful errors at https://filippo.io/age/report

--- a/testdata/encrypt-age-program-missing.txtar
+++ b/testdata/encrypt-age-program-missing.txtar
@@ -10,6 +10,5 @@ age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
 {"payload":"aGVsbG8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to encrypt payload: failed to encrypt payload with age: fork/exec /missing/age: no such file or directory

--- a/testdata/encrypt-no-recipients.txtar
+++ b/testdata/encrypt-no-recipients.txtar
@@ -7,6 +7,5 @@ cmp stderr stderr.txt
 {"payload":"c2VjcmV0"}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to encrypt payload: no recipients specified

--- a/testdata/invalid-json-input.txtar
+++ b/testdata/invalid-json-input.txtar
@@ -6,6 +6,5 @@ cmp stderr stderr.txt
 -- stdin.json --
 {
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to read stdin: unexpected EOF


### PR DESCRIPTION
## Summary
- delay writing header until encryption/decryption succeeds to avoid emitting magic header on errors
- adjust tests to expect empty stdout when operations fail

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `CI=true go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bccc140d148326a291fafdb70c5e04