### PR TITLE
Align recipients and identity file flags with age

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
    - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT` (values from both variables are merged; duplicates are ignored)
 
    CLI flags:
-   - `--age-identity-file`: path to your age identity file
-   - `--age-identity`: age identity string
-   - `--age-identity-command`: command whose output is the age identity
-   - `--age-recipient`: may be provided multiple times or as a comma-separated list of recipients
-   - `--age-recipients-file`: path to a file with newline-separated age recipients
+
+- `--identity-file`: path to your age identity file
+- `--identity`: age identity string
+- `--identity-command`: command whose output is the age identity
+- `--recipient`: may be provided multiple times or as a comma-separated list of recipients
+- `--recipients-file`: path to a file with newline-separated age recipients
 
 2. Configure OpenTofu to use the external method:
 

--- a/main.go
+++ b/main.go
@@ -89,12 +89,12 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 	encrypt := fs.Bool("encrypt", false, "encrypt payload")
 	decrypt := fs.Bool("decrypt", false, "decrypt payload")
 	versionFlag := fs.Bool("version", false, "print version")
-	var ageRecipients sliceFlag
-	fs.Var(&ageRecipients, "age-recipient", "age recipient")
-	ageRecipientsFileFlag := fs.String("age-recipients-file", os.Getenv("AGE_RECIPIENTS_FILE"), "age recipients file")
-	ageIdentityFileFlag := fs.String("age-identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
-	ageIdentityFlag := fs.String("age-identity", "", "age identity string")
-	ageIdentityCommandFlag := fs.String("age-identity-command", "", "command whose output is the age identity")
+	var recipientFlags sliceFlag
+	fs.Var(&recipientFlags, "recipient", "age recipient")
+	recipientsFileFlag := fs.String("recipients-file", os.Getenv("AGE_RECIPIENTS_FILE"), "age recipients file")
+	identityFileFlag := fs.String("identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
+	identityFlag := fs.String("identity", "", "age identity string")
+	identityCommandFlag := fs.String("identity-command", "", "command whose output is the age identity")
 	ageProgramFlag := fs.String("age-path", ageProgram, "path to age binary")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -108,7 +108,7 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 	}
 
 	var recipients []string
-	recipients = append(recipients, ageRecipients...)
+	recipients = append(recipients, recipientFlags...)
 
 	for _, envVar := range []string{"AGE_RECIPIENT", "SOPS_AGE_RECIPIENTS"} {
 		if val := os.Getenv(envVar); val != "" {
@@ -118,8 +118,8 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 		}
 	}
 
-	if *ageRecipientsFileFlag != "" {
-		rs, err := parseRecipientsFile(*ageRecipientsFileFlag)
+	if *recipientsFileFlag != "" {
+		rs, err := parseRecipientsFile(*recipientsFileFlag)
 		if err != nil {
 			return Config{}, fmt.Errorf("read age recipients file: %w", err)
 		}
@@ -156,14 +156,14 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 		cfg.mode = modeDecrypt
 	}
 
-	ageIdentityFile := *ageIdentityFileFlag
+	ageIdentityFile := *identityFileFlag
 	var ageIdentity string
 	if ageIdentityFile == "" {
 		switch {
-		case *ageIdentityFlag != "":
-			ageIdentity = *ageIdentityFlag
-		case *ageIdentityCommandFlag != "":
-			key, err := runKeyCommand(ctx, *ageIdentityCommandFlag)
+		case *identityFlag != "":
+			ageIdentity = *identityFlag
+		case *identityCommandFlag != "":
+			key, err := runKeyCommand(ctx, *identityCommandFlag)
 			if err != nil {
 				return Config{}, fmt.Errorf("failed to execute age identity command: %w", err)
 			}

--- a/testdata/decrypt-age-identity-command-flag-flag.txtar
+++ b/testdata/decrypt-age-identity-command-flag-flag.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --decrypt --age-identity-command 'cat key.txt'
+exec tofu-age-encryption --decrypt --identity-command 'cat key.txt'
 cmp stdout stdout.json
 
 -- input.json --

--- a/testdata/decrypt-age-identity-flag.txtar
+++ b/testdata/decrypt-age-identity-flag.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --decrypt --age-identity AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+exec tofu-age-encryption --decrypt --identity AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 cmp stdout stdout.json
 
 -- input.json --

--- a/testdata/decrypt-age-program-missing.txtar
+++ b/testdata/decrypt-age-program-missing.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! exec tofu-age-encryption --age-path /missing/age --decrypt --age-identity-file key.txt
+! exec tofu-age-encryption --age-path /missing/age --decrypt --identity-file key.txt
 cmp stdout stdout.json
 cmp stderr stderr.txt
 

--- a/testdata/decrypt-wrong-identity.txtar
+++ b/testdata/decrypt-wrong-identity.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! exec tofu-age-encryption --decrypt --age-identity-file key.txt
+! exec tofu-age-encryption --decrypt --identity-file key.txt
 cmp stdout stdout.json
 cmp stderr stderr.txt
 

--- a/testdata/decrypt.txtar
+++ b/testdata/decrypt.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --decrypt --age-identity-file key.txt
+exec tofu-age-encryption --decrypt --identity-file key.txt
 cmp stdout stdout.json
 
 -- input.json --

--- a/testdata/encrypt-age-program-missing.txtar
+++ b/testdata/encrypt-age-program-missing.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-! exec tofu-age-encryption --age-path /missing/age --encrypt --age-recipients-file recipients.txt
+! exec tofu-age-encryption --age-path /missing/age --encrypt --recipients-file recipients.txt
 cmp stdout stdout.json
 cmp stderr stderr.txt
 

--- a/testdata/encrypt-recipient-flag.txtar
+++ b/testdata/encrypt-recipient-flag.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --encrypt --age-recipient age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+exec tofu-age-encryption --encrypt --recipient age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
 
 stdin stdout
 exec sed 's/\("payload":"\)[^"]*/\1MASK/'

--- a/testdata/encrypt-recipients-file-flag.txtar
+++ b/testdata/encrypt-recipients-file-flag.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --encrypt --age-recipients-file recipients.txt
+exec tofu-age-encryption --encrypt --recipients-file recipients.txt
 
 stdin stdout
 exec sed 's/\("payload":"\)[^"]*/\1MASK/'

--- a/testdata/encrypt.txtar
+++ b/testdata/encrypt.txtar
@@ -1,5 +1,5 @@
 stdin input.json
-exec tofu-age-encryption --encrypt --age-recipients-file recipients.txt
+exec tofu-age-encryption --encrypt --recipients-file recipients.txt
 
 stdin stdout
 exec sed 's/\("payload":"\)[^"]*/\1MASK/'

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -4,21 +4,21 @@ cmp stdout help.txt
 
 -- help.txt --
 Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
-  -age-identity string
-    	age identity string
-  -age-identity-command string
-    	command whose output is the age identity
-  -age-identity-file string
-    	age identity file
   -age-path string
     	path to age binary (default "MASK")
-  -age-recipient value
-    	age recipient
-  -age-recipients-file string
-    	age recipients file
   -decrypt
     	decrypt payload
   -encrypt
     	encrypt payload
+  -identity string
+    	age identity string
+  -identity-command string
+    	command whose output is the age identity
+  -identity-file string
+    	age identity file
+  -recipient value
+    	age recipient
+  -recipients-file string
+    	age recipients file
   -version
     	print version

--- a/testdata/tofu-external-flags.txtar
+++ b/testdata/tofu-external-flags.txtar
@@ -23,8 +23,8 @@ AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 terraform {
   encryption {
     method "external" "age" {
-      encrypt_command = ["tofu-age-encryption", "--encrypt", "--age-recipient", "age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt"]
-      decrypt_command = ["tofu-age-encryption", "--decrypt", "--age-identity-file", "key.txt"]
+      encrypt_command = ["tofu-age-encryption", "--encrypt", "--recipient", "age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt"]
+      decrypt_command = ["tofu-age-encryption", "--decrypt", "--identity-file", "key.txt"]
     }
 
     state {


### PR DESCRIPTION
## Summary
- rename `--age-identity-file` to `--identity-file`
- rename `--age-identity` to `--identity`
- rename `--age-identity-command` to `--identity-command`
- rename `--age-recipient` to `--recipient`
- update docs and tests for new flags

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf19f6b20c8326a56641580d374923