### PR TITLE
Support file and command prefixes for identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 
    Environment variables:
    - `AGE_IDENTITY_FILE`: path to your age identity file
+   - `AGE_IDENTITY`: age identity string; supports `file:PATH`, `cmd:COMMAND`, and `command:COMMAND`
    - `AGE_IDENTITY_COMMAND` (alias: `AGE_IDENTITY_CMD`): command whose output is the age identity
    - `AGE_RECIPIENT`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
@@ -23,7 +24,7 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
    CLI flags:
 
 - `--identity-file`: path to your age identity file
-- `--identity`: age identity string
+- `--identity`: age identity string or `file:PATH`, `cmd:COMMAND`, `command:COMMAND`
 - `--identity-command`: command whose output is the age identity
 - `--recipient`: may be provided multiple times or as a comma-separated list of recipients
 - `--recipients-file`: path to a file with newline-separated age recipients

--- a/testdata/decrypt-age-identity-cmd-prefix.txtar
+++ b/testdata/decrypt-age-identity-cmd-prefix.txtar
@@ -1,0 +1,20 @@
+stdin input.json
+exec tofu-age-encryption --decrypt --identity 'cmd:cat key.txt'
+cmp stdout stdout.json
+
+env AGE_IDENTITY='cmd:cat key.txt'
+stdin input.json
+exec tofu-age-encryption --decrypt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/decrypt-age-identity-command-prefix.txtar
+++ b/testdata/decrypt-age-identity-command-prefix.txtar
@@ -1,0 +1,20 @@
+stdin input.json
+exec tofu-age-encryption --decrypt --identity 'command:cat key.txt'
+cmp stdout stdout.json
+
+env AGE_IDENTITY='command:cat key.txt'
+stdin input.json
+exec tofu-age-encryption --decrypt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/decrypt-age-identity-file-prefix.txtar
+++ b/testdata/decrypt-age-identity-file-prefix.txtar
@@ -1,0 +1,20 @@
+stdin input.json
+exec tofu-age-encryption --decrypt --identity file:key.txt
+cmp stdout stdout.json
+
+env AGE_IDENTITY='file:key.txt'
+stdin input.json
+exec tofu-age-encryption --decrypt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -11,7 +11,7 @@ Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
   -encrypt
     	encrypt payload
   -identity string
-    	age identity string
+    	age identity string, file:PATH or cmd:COMMAND
   -identity-command string
     	command whose output is the age identity
   -identity-file string


### PR DESCRIPTION
## Summary
- allow `--identity` and `AGE_IDENTITY` to accept `file:`, `cmd:` and `command:` prefixes
- document and test new identity prefix handling

## Testing
- `go vet ./...`
- `go mod download`
- `go test ./...`
- `CI=true go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf2800b9b08326921d566b7f825a06