### PR TITLE
Support AGE_* environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ OpenTofu encrypts state with a symmetric key derived from a shared passphrase th
 1. Provide the age recipient and identity file using either environment variables or CLI flags:
 
    Environment variables:
-   - `AGE_IDENTITY_FILE`: path to your age identity file
-   - `AGE_IDENTITY`: age identity string; supports `file:PATH`, `cmd:COMMAND`, and `command:COMMAND`
+   - `AGE_IDENTITY_FILE` (alias: `AGE_KEY_FILE`): path to your age identity file
+   - `AGE_IDENTITY` (alias: `AGE_KEY`): age identity string; supports `file:PATH`, `cmd:COMMAND`, and `command:COMMAND`
    - `AGE_IDENTITY_COMMAND` (alias: `AGE_IDENTITY_CMD`): command whose output is the age identity
-   - `AGE_RECIPIENT`: comma-separated list of age recipients
+   - `AGE_RECIPIENT` or `AGE_RECIPIENTS`: comma-separated list of age recipients
    - `AGE_RECIPIENTS_FILE`: path to a file with newline-separated age recipients
 
    The following `SOPS_`-prefixed variables are also supported as aliases for compatibility with tools that expect them:
    - `SOPS_AGE_KEY_FILE`: alias for `AGE_IDENTITY_FILE`
    - `SOPS_AGE_KEY`: age identity string
    - `SOPS_AGE_KEY_CMD`: alias for `AGE_IDENTITY_COMMAND`
-   - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT` (values from both variables are merged; duplicates are ignored)
+   - `SOPS_AGE_RECIPIENTS`: alias for `AGE_RECIPIENT`/`AGE_RECIPIENTS` (values from both variables are merged; duplicates are ignored)
 
    CLI flags:
 

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 		return Config{}, err
 	}
 
-	for _, envVar := range []string{"AGE_RECIPIENT", "SOPS_AGE_RECIPIENTS"} {
+	for _, envVar := range []string{"AGE_RECIPIENT", "AGE_RECIPIENTS", "SOPS_AGE_RECIPIENTS"} {
 		if val := os.Getenv(envVar); val != "" {
 			for _, r := range parseRecipients(val) {
 				recipients[r] = true
@@ -178,6 +178,10 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 				return Config{}, fmt.Errorf("failed to execute age identity command: %w", err)
 			}
 			ageIdentity = key
+		case os.Getenv("AGE_KEY_FILE") != "":
+			ageIdentityFile = os.Getenv("AGE_KEY_FILE")
+		case os.Getenv("AGE_KEY") != "":
+			ageIdentity = os.Getenv("AGE_KEY")
 		case os.Getenv("SOPS_AGE_KEY_FILE") != "":
 			ageIdentityFile = os.Getenv("SOPS_AGE_KEY_FILE")
 		case os.Getenv("SOPS_AGE_KEY") != "":

--- a/testdata/decrypt-age-key-env.txtar
+++ b/testdata/decrypt-age-key-env.txtar
@@ -1,0 +1,13 @@
+env AGE_KEY=AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+stdin cipher.json
+exec tofu-age-encryption --decrypt
+cmp stdout stdout.json
+cmp stderr stderr.txt
+
+-- cipher.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --

--- a/testdata/encrypt-age-env.txtar
+++ b/testdata/encrypt-age-env.txtar
@@ -1,0 +1,25 @@
+env AGE_RECIPIENTS=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+env AGE_KEY_FILE=$WORK/key.txt
+stdin plain.json
+exec tofu-age-encryption --encrypt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+stdin cipher.json
+exec tofu-age-encryption --decrypt
+cmp stdout stdout.json
+cmp stderr stderr.txt
+
+-- plain.json --
+{"payload":"c2VjcmV0"}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}
+-- stderr.txt --


### PR DESCRIPTION
## Summary
- allow `AGE_KEY_FILE`, `AGE_KEY`, and `AGE_RECIPIENTS` in configuration alongside existing `SOPS_*` aliases
- document AGE environment variables and update compatibility notes
- add test coverage for AGE env vars
- rename AGE env var test data scripts to match naming conventions

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf62aa51d4832683e592f1491f733a