### PR TITLE
Document manual state recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ output "pet" {
 $ tofu init
 $ tofu apply
 ```
+
+## Manual state recovery
+
+If the `tofu-age-encryption` binary is unavailable, you can decrypt an existing state file using common command-line tools:
+
+```sh
+jq --raw-output '.encrypted_data' terraform.tfstate | base64 --decode >state.age
+age --decrypt --identity key.txt state.age >state.json
+jq . state.json
+```
+
+This process does not require `tofu-age-encryption` and can be used to recover the plain text state for backup or debugging.

--- a/testdata/manual-state-recovery.txtar
+++ b/testdata/manual-state-recovery.txtar
@@ -1,0 +1,47 @@
+env TF_IN_AUTOMATION=true
+env TF_INPUT=false
+env TF_CLI_ARGS=-no-color
+
+env AGE_RECIPIENT=age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+env AGE_IDENTITY_FILE=$WORK/key.txt
+
+exec tofu init
+exec tofu apply --auto-approve --lock=false
+exec jq --raw-output '.encrypted_data' terraform.tfstate
+cp stdout state.b64
+stdin state.b64
+exec base64 --decode
+cp stdout state.age
+exec age --decrypt --identity key.txt state.age
+cp stdout state.json
+exec jq --raw-output '.outputs.foo.value' state.json
+stdout bar
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- main.tf --
+terraform {
+  encryption {
+    method "external" "age" {
+      encrypt_command = ["tofu-age-encryption", "--encrypt"]
+      decrypt_command = ["tofu-age-encryption", "--decrypt"]
+    }
+
+    state {
+      method = method.external.age
+      enforced = true
+    }
+
+    plan {
+      method = method.external.age
+      enforced = true
+    }
+  }
+}
+
+output "foo" {
+  value = "bar"
+}


### PR DESCRIPTION
## Summary
- document how to manually decrypt an encrypted state using jq, base64, and age
- add test script that exercises the manual recovery steps

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf6419989c8326940b8f2a1eed03cb