### PR TITLE
Add command aliases for encrypt, decrypt, and version

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,13 @@ func parseRecipients(value string) []string {
 }
 
 func parseConfig(ctx context.Context, args []string) (Config, error) {
+	if len(args) > 0 {
+		switch args[0] {
+		case "encrypt", "decrypt", "version":
+			args[0] = "--" + args[0]
+		}
+	}
+
 	ageProgram := AgeProgram
 	if ageProgram == "" || ageProgram == "age" {
 		if path, err := exec.LookPath("age"); err == nil {

--- a/testdata/decrypt-command.txtar
+++ b/testdata/decrypt-command.txtar
@@ -1,0 +1,15 @@
+stdin input.json
+exec tofu-age-encryption decrypt --identity-file key.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/encrypt-command.txtar
+++ b/testdata/encrypt-command.txtar
@@ -1,0 +1,16 @@
+stdin input.json
+exec tofu-age-encryption encrypt --recipients-file recipients.txt
+
+stdin stdout
+exec sed 's/\("payload":"\)[^"]*/\1MASK/'
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- recipients.txt --
+age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"MASK"}

--- a/testdata/version-command.txtar
+++ b/testdata/version-command.txtar
@@ -1,0 +1,3 @@
+exec tofu-age-encryption version
+stdout 'tofu-age-encryption version [0-9]+\.[0-9]+\.[0-9]+'
+! stderr .


### PR DESCRIPTION
## Summary
- Allow `encrypt`, `decrypt`, and `version` subcommands as equivalents to their respective flags
- Add regression tests for these command aliases

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `CI=true go test ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bf74907ce48326b62b7c2a12da11fc