### PR TITLE
test: ensure CLI flags take precedence over env vars

### DIFF
--- a/testdata/decrypt-age-identity-file-env-flag.txtar
+++ b/testdata/decrypt-age-identity-file-env-flag.txtar
@@ -1,0 +1,16 @@
+env AGE_IDENTITY_FILE=$WORK/missing.txt
+stdin input.json
+exec tofu-age-encryption --decrypt --identity-file key.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
+
+-- key.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}


### PR DESCRIPTION
## Summary
- add regression test showing `--identity-file` flag overrides conflicting `AGE_IDENTITY_FILE`

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c056691fbc8326b379b087d24b2464