### PR TITLE
support multiple recipients-file flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,7 +98,11 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 		}
 		return nil
 	})
-	recipientsFileFlag := fs.String("recipients-file", "", "age recipients file")
+	var recipientsFiles []string
+	fs.Func("recipients-file", "age recipients file", func(value string) error {
+		recipientsFiles = append(recipientsFiles, value)
+		return nil
+	})
 	identityFileFlag := fs.String("identity-file", os.Getenv("AGE_IDENTITY_FILE"), "age identity file")
 	identityFlag := fs.String("identity", os.Getenv("AGE_IDENTITY"), "age identity string, file:PATH or cmd:COMMAND")
 	identityCommandFlag := fs.String("identity-command", "", "command whose output is the age identity")
@@ -122,11 +126,12 @@ func parseConfig(ctx context.Context, args []string) (Config, error) {
 		}
 	}
 
-	recipientsFile := *recipientsFileFlag
-	if recipientsFile == "" {
-		recipientsFile = os.Getenv("AGE_RECIPIENTS_FILE")
+	if len(recipientsFiles) == 0 {
+		if env := os.Getenv("AGE_RECIPIENTS_FILE"); env != "" {
+			recipientsFiles = append(recipientsFiles, env)
+		}
 	}
-	if recipientsFile != "" {
+	for _, recipientsFile := range recipientsFiles {
 		rs, err := parseRecipientsFile(recipientsFile)
 		if err != nil {
 			return Config{}, fmt.Errorf("read age recipients file: %w", err)

--- a/testdata/encrypt-recipient-duplicate-flag.txtar
+++ b/testdata/encrypt-recipient-duplicate-flag.txtar
@@ -1,0 +1,22 @@
+stdin input.json
+exec tofu-age-encryption --encrypt --recipient age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt --recipient age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key1.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- key1.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/encrypt-recipient-multi-flag.txtar
+++ b/testdata/encrypt-recipient-multi-flag.txtar
@@ -1,0 +1,31 @@
+stdin input.json
+exec tofu-age-encryption --encrypt --recipient age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt --recipient age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key1.txt
+cmp stdout stdout.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key2.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- key1.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- key2.txt --
+# created: 2025-09-06T20:25:14Z
+# public key: age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+AGE-SECRET-KEY-17Y29Y9E2XTJ6ZPZ6X3YNSE3NVREHJG64GFPYWNRF0MSU4L0E3V5Q84AFZH
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/encrypt-recipient-recipients-file-mix-flag.txtar
+++ b/testdata/encrypt-recipient-recipients-file-mix-flag.txtar
@@ -1,0 +1,44 @@
+stdin input.json
+exec tofu-age-encryption --encrypt --recipient age1yh02jaysl73ph50r4xrage2hvstp9hjy72r4p4tlv99zveyf9fvsxc4h9n --recipients-file recipients.txt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key1.txt
+cmp stdout stdout.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key2.txt
+cmp stdout stdout.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key3.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- recipients.txt --
+age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+
+-- key1.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- key2.txt --
+# created: 2025-09-06T20:25:14Z
+# public key: age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+AGE-SECRET-KEY-17Y29Y9E2XTJ6ZPZ6X3YNSE3NVREHJG64GFPYWNRF0MSU4L0E3V5Q84AFZH
+
+-- key3.txt --
+# created: 2025-09-06T01:25:41Z
+# public key: age1yh02jaysl73ph50r4xrage2hvstp9hjy72r4p4tlv99zveyf9fvsxc4h9n
+AGE-SECRET-KEY-1UTNEY8FW0GN8CXZT8KERWNL9TGDVMQYRT86C6WZQGKTDWTRL7E4Q6CMNMM
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/encrypt-recipients-file-duplicate-flag.txtar
+++ b/testdata/encrypt-recipients-file-duplicate-flag.txtar
@@ -1,0 +1,25 @@
+stdin input.json
+exec tofu-age-encryption --encrypt --recipients-file recipients.txt --recipients-file recipients.txt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key1.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- recipients.txt --
+age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+
+-- key1.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/encrypt-recipients-file-multi-flag.txtar
+++ b/testdata/encrypt-recipients-file-multi-flag.txtar
@@ -1,0 +1,37 @@
+stdin input.json
+exec tofu-age-encryption --encrypt --recipients-file recipients1.txt --recipients-file recipients2.txt
+
+stdin stdout
+exec tail -n +2
+cp stdout cipher.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key1.txt
+cmp stdout stdout.json
+
+stdin cipher.json
+exec tofu-age-encryption --decrypt --identity-file key2.txt
+cmp stdout stdout.json
+
+-- input.json --
+{"payload":"c2VjcmV0"}
+
+-- recipients1.txt --
+age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+
+-- recipients2.txt --
+age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+
+-- key1.txt --
+# created: 2025-09-05T17:27:52-07:00
+# public key: age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
+AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
+
+-- key2.txt --
+# created: 2025-09-06T20:25:14Z
+# public key: age19xls7dzpf24kzfd0vu2vy7w3e4r7cxsxgwgqeccupzswzpktxu6qqqd7vt
+AGE-SECRET-KEY-17Y29Y9E2XTJ6ZPZ6X3YNSE3NVREHJG64GFPYWNRF0MSU4L0E3V5Q84AFZH
+
+-- stdout.json --
+{"magic":"OpenTofu-External-Encryption-Method","version":1}
+{"payload":"c2VjcmV0"}

--- a/testdata/help-flag.txtar
+++ b/testdata/help-flag.txtar
@@ -18,7 +18,7 @@ Usage: tofu-age-encryption [--encrypt | --decrypt] [options]
     	age identity file
   -recipient value
     	age recipient
-  -recipients-file string
+  -recipients-file value
     	age recipients file
   -version
     	print version


### PR DESCRIPTION
## Summary
- allow repeating `--recipients-file` flags and merge all entries
- add test cases covering multiple recipients, recipients files, and mixed flags

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c059a4899c8326abdbe0f1b0ee0642