### PR TITLE
fix: avoid header on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,14 +247,6 @@ func main() {
 	out := io.Writer(os.Stdout)
 	outputDesc := "stdout"
 
-	header := Header{
-		"OpenTofu-External-Encryption-Method",
-		1,
-	}
-	if err := json.NewEncoder(out).Encode(header); err != nil {
-		log.Fatalf("Failed to write %s: %v", outputDesc, err)
-	}
-
 	dec := json.NewDecoder(in)
 	var inputData Input
 	var first json.RawMessage
@@ -262,6 +254,10 @@ func main() {
 		log.Fatalf("Failed to read %s: %v", inputDesc, err)
 	}
 	var hdr Header
+	header := Header{
+		"OpenTofu-External-Encryption-Method",
+		1,
+	}
 	if err := json.Unmarshal(first, &hdr); err == nil && hdr.Magic == header.Magic {
 		if err := dec.Decode(&first); err != nil {
 			log.Fatalf("Failed to read %s: %v", inputDesc, err)
@@ -291,11 +287,10 @@ func main() {
 	output := Output{
 		Payload: outputPayload,
 	}
-	outputData, err := json.Marshal(output)
-	if err != nil {
-		log.Fatalf("Failed to stringify output: %v", err)
+	if err := json.NewEncoder(out).Encode(header); err != nil {
+		log.Fatalf("Failed to write %s: %v", outputDesc, err)
 	}
-	if _, err = fmt.Fprintln(out, string(outputData)); err != nil {
+	if err := json.NewEncoder(out).Encode(output); err != nil {
 		log.Fatalf("Failed to write %s: %v", outputDesc, err)
 	}
 }

--- a/testdata/decrypt-age-program-missing.txtar
+++ b/testdata/decrypt-age-program-missing.txtar
@@ -12,6 +12,5 @@ AGE-SECRET-KEY-1PM25GKMYEWAKGVNM44FPMFXMEEGVDTXUEN3H3LNH2JACJA0UNZPQG00E7N
 {"payload":"aGVsbG8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: age program not found: /missing/age

--- a/testdata/decrypt-missing-age-identity-file-env.txtar
+++ b/testdata/decrypt-missing-age-identity-file-env.txtar
@@ -9,7 +9,6 @@ cmp stderr stderr.txt
 {"payload":"c2VjcmV0"}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: age: error: reading "/tmp/missing": failed to open file: open /tmp/missing: no such file or directory
 age: report unexpected or unhelpful errors at https://filippo.io/age/report

--- a/testdata/decrypt-no-identity.txtar
+++ b/testdata/decrypt-no-identity.txtar
@@ -7,6 +7,5 @@ cmp stderr stderr.txt
 {"payload":"YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmRnBqV1pZWDV3WHhQOXRjL3JLN2ZxdnBvTW02THdLOXIvVFVKa2s2S1Y0CkFjV1RZK3BYM01zaDBLbkIrK0tHczhJVVRvU3ZJY1ROV0JvNDNDaE9OVDQKLS0tIENqRjlzUzNSY2pta1JkeEFmR1pYTGpNMmREbk1SSEtTVS9mSHEwQWZSZVUK01JDFoTH0Yl/s/VJqNKy7Tyo7xMYwJHZWswI3ANcF3LoPaUQAU8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: no identity specified

--- a/testdata/decrypt-wrong-identity.txtar
+++ b/testdata/decrypt-wrong-identity.txtar
@@ -12,7 +12,6 @@ cmp stderr stderr.txt
 AGE-SECRET-KEY-19LDXPQ0ZFT5VRG2LT84470RAJ79QZU9HWJJ97LM7YF0KWX6GCGHSLEVXKZ
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to decrypt payload: age: error: no identity matched any of the recipients
 age: report unexpected or unhelpful errors at https://filippo.io/age/report

--- a/testdata/encrypt-age-program-missing.txtar
+++ b/testdata/encrypt-age-program-missing.txtar
@@ -10,6 +10,5 @@ age1s2r63x2q98nmv8ppjv5c2zv5xlm4lp0makhmtsumglwhhwnt2e5srs47qt
 {"payload":"aGVsbG8="}
 
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to encrypt payload: age program not found: /missing/age

--- a/testdata/encrypt-no-recipients-pipe.txtar
+++ b/testdata/encrypt-no-recipients-pipe.txtar
@@ -1,10 +1,6 @@
-stdin input.json
-! exec tofu-age-encryption --encrypt
+! exec sh -c 'printf "{\"payload\":\"dGVzdA==\"}" | tofu-age-encryption --encrypt'
 cmp stdout stdout.json
 cmp stderr stderr.txt
-
--- input.json --
-{"payload":"c2VjcmV0"}
 
 -- stdout.json --
 -- stderr.txt --

--- a/testdata/invalid-json-input.txtar
+++ b/testdata/invalid-json-input.txtar
@@ -6,6 +6,5 @@ cmp stderr stderr.txt
 -- stdin.json --
 {
 -- stdout.json --
-{"magic":"OpenTofu-External-Encryption-Method","version":1}
 -- stderr.txt --
 Failed to read stdin: unexpected EOF

--- a/testdata/invalid-json-pipe.txtar
+++ b/testdata/invalid-json-pipe.txtar
@@ -1,0 +1,7 @@
+! exec sh -c 'echo invalid json | tofu-age-encryption --encrypt'
+cmp stdout stdout.json
+cmp stderr stderr.txt
+
+-- stdout.json --
+-- stderr.txt --
+Failed to read stdin: invalid character 'i' looking for beginning of value


### PR DESCRIPTION
## Summary
- delay writing magic header until encryption or decryption succeeds
- update error-path tests to expect empty stdout

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0b2cf26588326ae8553edfadc5e8e