### PR TITLE
Decode input without optional header

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,18 +258,8 @@ func main() {
 
 	dec := json.NewDecoder(in)
 	var inputData Input
-	var first json.RawMessage
-	if err := dec.Decode(&first); err != nil {
+	if err := dec.Decode(&inputData); err != nil {
 		log.Fatalf("Failed to read %s: %v", inputDesc, err)
-	}
-	var hdr Header
-	if err := json.Unmarshal(first, &hdr); err == nil && hdr.Magic == header.Magic {
-		if err := dec.Decode(&first); err != nil {
-			log.Fatalf("Failed to read %s: %v", inputDesc, err)
-		}
-	}
-	if err := json.Unmarshal(first, &inputData); err != nil {
-		log.Fatalf("Failed to parse %s: %v", inputDesc, err)
 	}
 
 	var (


### PR DESCRIPTION
## Summary
- Remove optional input header handling
- Decode first JSON input directly into the Input struct

## Testing
- `go vet ./...`
- `go test ./...`
- `CI=true go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c0cb7dbf1c8326a10efe9ac762d72c