### PR TITLE
Opt into testscript update script behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,17 +53,17 @@ The test suite uses [testscript](https://pkg.go.dev/github.com/rogpeppe/go-inter
 
 ### Testdata updates and CI
 
-Running the tests without the `CI` environment variable may rewrite expected results in `testdata`:
+Set `UPDATE_SCRIPTS` to a truthy value such as `true` or `1` to rewrite expected results in `testdata`:
 
 ```sh
-$ go test ./...
+$ UPDATE_SCRIPTS=true go test ./...
 $ git diff
 ```
 
-Review the diff to understand any changes. After updating testdata, rerun the suite with the flag set to ensure it still passes in continuous integration:
+Review the diff to understand any changes. After updating testdata, rerun the suite without `UPDATE_SCRIPTS` to ensure it still passes in continuous integration:
 
 ```sh
-$ CI=true go test ./...
+$ go test ./...
 ```
 
 ## Formatting

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -14,9 +15,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestScript(t *testing.T) {
+	updateScripts, _ := strconv.ParseBool(os.Getenv("UPDATE_SCRIPTS"))
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata",
 		ContinueOnError: true,
-		UpdateScripts:   os.Getenv("CI") == "",
+		UpdateScripts:   updateScripts,
 	})
 }


### PR DESCRIPTION
## Summary
- clarify that UPDATE_SCRIPTS accepts truthy values such as true or 1 when regenerating testdata

## Testing
- go test ./... *(hangs locally because the tofu binary is unavailable, command interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb397b7dc8326bf86d81b8f2d8513